### PR TITLE
Add support for WSS protocol

### DIFF
--- a/MaterialDeck.js
+++ b/MaterialDeck.js
@@ -133,7 +133,9 @@ async function analyzeWSmessage(msg){
  */
 function startWebsocket() {
     const address = game.settings.get(moduleName,'address');
-    ws = new WebSocket('ws://'+address+'/');
+    const url = address.startsWith('wss://') ? address : ('ws://'+address+'/');
+
+    ws = new WebSocket(url);
 
     ws.onmessage = function(msg){
         //console.log(msg);


### PR DESCRIPTION
As I'm hosting my Foundry instance that is available to public I'm using HTTPS protocol for it. Due to that I need to use `wss` for WebSockets. I added a simple check that allows me to provide full URL that contains `wss://` prefix and everything works fine.

I'll prepare a better PR that will use setting to choose if you're using secure connection for Foundry, but for now a simple code change resolves my problem.