### PR TITLE
Added rollItem() family of methods

### DIFF
--- a/src/systems/demonlord.js
+++ b/src/systems/demonlord.js
@@ -130,4 +130,8 @@ export class demonlord{
     getSpellUses(token,level,item) {
         return;
     }
+
+    rollItem(item) {
+        return item.roll()
+    }
 }

--- a/src/systems/dnd35e.js
+++ b/src/systems/dnd35e.js
@@ -195,4 +195,8 @@ export class dnd35e{
             maximum: item.maxCharges
         }
     }
+
+    rollItem(item) {
+        return item.roll()
+    }
 }

--- a/src/systems/dnd5e.js
+++ b/src/systems/dnd5e.js
@@ -198,4 +198,8 @@ export class dnd5e{
             maximum: token.actor.data.data.spells?.[`spell${level}`].max
         }
     }
+
+    rollItem(item) {
+        return item.roll()
+    }
 }

--- a/src/systems/pf2e.js
+++ b/src/systems/pf2e.js
@@ -192,4 +192,8 @@ export class pf2e{
             maximum: spellbook.data.data.slots?.[`slot${level}`].max
         }
     }
+
+    rollItem(item) {
+        return item.roll()
+    }
 }

--- a/src/systems/tokenHelper.js
+++ b/src/systems/tokenHelper.js
@@ -238,4 +238,8 @@ export class TokenHelper{
     getSpellUses(token,level,item) {
         return this.system.getSpellUses(token,level,item);
     }
+
+    rollItem(item) {
+        return this.system.rollItem(item);
+    }
 }

--- a/src/token.js
+++ b/src/token.js
@@ -739,7 +739,9 @@ export class TokenControl{
             items = this.sortItems(items);
 
             const item = items[itemNr];
-            if (item != undefined) item.roll();
+            if (item != undefined) {
+                tokenHelper.rollItem(item);
+            }
             
         }
     }


### PR DESCRIPTION
# Why this PR

I'm working on the wfrp4e system, whose item rolling is different from the standard item rolling. Instead of:

```javascript
item.roll()
```

it should instead be:

```javascript
game.wfrp4e.utility.rollItemMacro(item.name, item.type, false);
```

After discussion with @CDeenen , rather than put an ugly if/else block in `token.js`, the decision was made to create a new method in the systems, `rollItem`, that implements this functionality on a system-by-system basis. 

# How
The change itself is straightforward, because the wfrp module is still in branch: just call `item.roll()` in all systems code.

# Testing
I opened a 5e module and did some rolling of an item both via streamdeck and via Foundry, and the item rolled successfully.

# Miscellany
If preference is to review all the code all at once for `wfrp4` fork/branch, happy to close this PR out assuming its implementation looks sane. (I've already merged it into my feature branch.)
 