### PR TITLE
Fixing undefined device when looping over buttonContext.

### DIFF
--- a/src/streamDeck.js
+++ b/src/streamDeck.js
@@ -61,7 +61,7 @@ export class StreamDeck{
 
     clearContext(device,action,coordinates = {column:0,row:0}){
         for (let d of this.buttonContext) {
-            if (d.device == device) {
+            if (d?.device == device) {
                 const num = coordinates.column + coordinates.row*d.size.columns;
                 d.buttons[num] = undefined;
                 return;
@@ -241,7 +241,7 @@ export class StreamDeck{
         
         //if (src != 'modules/MaterialDeck/img/black.png')
         for (let d of this.buttonContext) {
-            if (d.device == device) {
+            if (d?.device == device) {
                 for (let i=0; i<d.buttons.length; i++){
                     if (clock != false) break;
                     if (d.buttons[i] == undefined) continue;


### PR DESCRIPTION
When looping over this.buttonContext within clearContext and setIcon methods, there are empty array entries. To avoid the loop being aborted early, we add an optional chain before trying to access '.device' from an empty array entry. 

Example Errors before this fix:

![image](https://user-images.githubusercontent.com/16811404/138578324-a9416d5a-c7ab-4411-a5e2-a2cd219d462c.png)
