### PR TITLE
Fix for error in template.js import statement

### DIFF
--- a/src/systems/template.js
+++ b/src/systems/template.js
@@ -10,7 +10,7 @@
  * return compatibleSystem('1.6.3') ? [value in v1.6.3+] : [value pre v1.6.3];
  */
 
-import { compatibleCore, compatibleSystem } from "../misc";
+import { compatibleCore, compatibleSystem } from "../misc.js";
 
 /**
  * Proficiency colors to show if a token is proficient in for example a skill


### PR DESCRIPTION
The module does not load due to import {} from "../misc" I'm guessing this is either an oversight or something that changed in javascript/node since the template was created.

Addresses #108 